### PR TITLE
Add support of JP6.2.1 and bump version to 4.3.2+1.0.0

### DIFF
--- a/jtop/__init__.py
+++ b/jtop/__init__.py
@@ -31,5 +31,5 @@ __cr__ = "(c) 2024, RB"
 __copyright__ = "(c) 2024, Raffaello Bonghi"
 # Version package
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/#choosing-a-versioning-scheme
-__version__ = "4.3.3"
+__version__ = "4.3.2+1.0.0"
 # EOF

--- a/jtop/__init__.py
+++ b/jtop/__init__.py
@@ -31,5 +31,5 @@ __cr__ = "(c) 2024, RB"
 __copyright__ = "(c) 2024, Raffaello Bonghi"
 # Version package
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/#choosing-a-versioning-scheme
-__version__ = "4.3.2"
+__version__ = "4.3.3"
 # EOF

--- a/jtop/core/jetson_variables.py
+++ b/jtop/core/jetson_variables.py
@@ -42,6 +42,7 @@ if not sys.warnoptions:
 # https://developer.nvidia.com/embedded/jetpack-archive
 NVIDIA_JETPACK = {
     # -------- JP6 --------
+    "36.4.4": "6.2.1",
     "36.4.3": "6.2",
     "36.4.2": "6.1 (rev1)",
     "36.4.0": "6.1",


### PR DESCRIPTION
<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

New Jetpack version is added following https://rnext.it/jetson_stats/contributing.html#add-a-new-jetpack

Version is updated to `4.3.2+1.0.0` and not to `4.3.3` to let the upstream repo tag `4.3.3` once ready