### PR TITLE
chore: jtop.service does not need to wait for multi-user.target

### DIFF
--- a/services/jtop.service
+++ b/services/jtop.service
@@ -15,7 +15,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 [Unit]
 Description=jtop service
-After=multi-user.target
+After=network.target
 
 [Service]
 # Type=exec


### PR DESCRIPTION
This PR fixes the jtop service hanging and waiting for `multi-user.target` to complete before starting.

I'm not sure that network.target is necessary, but it is enough to fix the issue of infinite loop of dependencies